### PR TITLE
distributed => decentralized in DID definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,7 +1505,7 @@ in a network to make a decision in a deterministic fashion.</p>
 state machine where the accuracy of the ledger can be mathematically
 proven to be correct.</p>
 <p><dfn class "dfn-paneled" data-dfn-type="dfn" data-noexport id="micro-ledger">micro-ledger:</dfn> An append only tamper-resistent ledger that shares the hashed linked list characteristics of fully deployed distributed ledger technologies, but without the full overhead of consensus algorithms.</p>
-<p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="did">DID</dfn>: a distributed identitfier.</p>
+<p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="did">DID</dfn>: a decentralized identitfier.</p>
 <p><dfn data-dfn-type="dfn" data-noexport id="decentralized-system">decentralized system<a class="self-link" href="#decentralized-system"></a></dfn>: A system in which lower level
 components operate on local information to accomplish global goals. For
 example, an ant colony is a decentralized system as there is no central


### PR DESCRIPTION
The document links extensively to a DID spec where the first D stands for "decentralized" so defining the acronym in the same way here makes sense.